### PR TITLE
Replace obsolete AC_TRY_RUN macro

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -81,16 +81,16 @@ if test "$PHP_CMARK" != "no"; then
     AC_MSG_CHECKING([for cmark minimal version])
     old_CFLAGS=$CFLAGS
     CFLAGS="-I$CMARK_DIR/include"
-    AC_TRY_RUN([
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <cmark.h>
 int main() {
   return (CMARK_VERSION < (($LIBCMARK_MIN_MAJOR << 16) | ($LIBCMARK_MIN_MINOR << 8)) ? 1 : 0);
 }
-    ], [
+    ]])],[
       AC_MSG_RESULT([ok])
-    ], [
+    ],[
       AC_MSG_ERROR(system libcmark is too old: version 0.28 required)
-    ])
+    ],[])
     CFLAGS=$old_CFLAGS
   fi
 


### PR DESCRIPTION
Autoconf has made several macros obsolete in 2001 in version 2.50. These include the `AC_TRY_RUN` macro:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.3

It should be replaced with the current `AC_RUN_IFELSE` instead.

PHP 5.3 required Autoconf 2.13 (released in 1999) or newer, since PHP 5.4 the autoconf 2.59 (released in 2003) or newer was required, and since PHP 7.2, autoconf 2.64 (released in 2008) or newer is 
required.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible with at least PHP versions 5.4 and up, on some systems even with PHP 5.3.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fFOO_005fIFELSE-vs-AC_005fTRY_005fFOO.html

This patch was done with the help of:

```bash
autoupdate config.m4
```

Thank you for considering merging this or checking it out. In case of doubts or questions just ask...